### PR TITLE
Week 01: GSF Suggestions

### DIFF
--- a/01-prompt-engineering/04-chain-of-verification.md
+++ b/01-prompt-engineering/04-chain-of-verification.md
@@ -9,14 +9,15 @@ Hallucinations occur when the answer appears plausible but is factually incorrec
 3. **Execute Verification**: The verification questions are _independently_ answered to minimize any potential bias. 
 4. **Final Refined Answer Generation**: Based on the results of the verification process, a final refined answer is generated. 
 
-This procedure is the backbone of the method. The implementation can be done in a couple of ways. The original proposals are the following, but feel free to come up with your one ones 😉:
+This procedure is the backbone of the method. The implementation can be done in a couple of ways. The original proposals are the following, but feel free to come up with your own ones 😉:
 
-
-- **Joint**: In this method both the planning and verification steps are done jointly using a single prompt request made to the LLM. Although, this method is not recommended as the verification result can be hallucinated and affected by the bias. 
-- **2-Step**: In the first step the verification questions are generated and in the second step the verification questions are answered. All questions and answers are generated in batches.
-- **Factored**: Instead of using one big response, it is better answering each question separately. This way, the answers won’t be just copies of the baseline response. This approach also helps avoid confusion between different questions and it might be able to handle more verification questions, even though it could be computationally expensive.
-
-- **Factored + Revise**: After we get the answers of the verification questions, the CoVe pipeline needs to check if the answers match with the baseline response. This is done by comparing the answers to the baseline response. This as a separate step by using an additional prompt for the LLM. This extra step helps the system think more carefully about this comparison.
+- **Joint**: In this method, both the planning and verification steps are done jointly using a single prompt request made to the LLM. However, this method is not recommended as the verification result can be hallucinated and affected by bias.
+    
+- **2-Step**: In the first step, verification questions are generated, and in the second step, they are answered. All questions and answers are generated in batches.
+    
+- **Factored**: Instead of using one big response, it is better to answer each question separately. This way, the answers won’t be just copies of the baseline response. This approach also helps avoid confusion between different questions, and it might be able to handle more verification questions, even though it could be computationally expensive.
+    
+- **Factored + Revise**: After we get the answers to the verification questions, the CoVe pipeline needs to check if the answers match the baseline response. This is done by comparing the answers to the baseline response, which is done as a separate step using an additional prompt for the LLM. This extra step helps the system think more carefully about this comparison.
 
 <img src="../images/NDRSsnvyTd4hd.jpg" alt="" width="300" height="auto">
 


### PR DESCRIPTION
## Suggestions

- Chain-of-Thought is practically the same as DL.ai's idea of "Break Tasks into Steps" from its second principle **Give the Model Time to Think**. We should merge both of these ideas. 
    - Also, the idea of ReAct is an extension of CoT, so it makes sense to follow up from there.
- CoV diverges from the rest of the content. If I understand correctly, CoV is a way to evaluate our answers, so we should have a section just on evaluation and include this there.
CoD is another idea for **Give the Model Time to Think**. We could combine all of these ideas.